### PR TITLE
Tasks v2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :email, :password, :gender_id, :hobby, :comment, :age, :prefecture_id, :city, :address])
   end
 
+  def after_sign_out_path_for(resource_or_scope)
+    root_path
+  end
+
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_action :authenticate_user!, except: :index
+
   def index
     @events = Event.all
     @userevents = UserEvent.all

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -54,10 +54,4 @@ class TasksController < ApplicationController
   def define_event
     @event = Event.find(params[:event_id])
   end
-
-  # def user_id_must_exist
-  #   if @task.user_id = "" || !@task.user_id
-  #     errors.add(:user_id, "person in charge must be checked")
-  #   end
-  # end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
     @task.event = @event
-    @task.user = User.find(params[:user_id])
+    @task.users = User.find(params[:user_ids])
     if @task.valid?
       @task.save
       redirect_to event_tasks_path(@event)
@@ -31,6 +31,7 @@ class TasksController < ApplicationController
 
   def update
     @task = Task.find(params[:id])
+    @task.users = User.find(params[:user_ids])
     if @task.valid?
       @task.update(task_params)
       redirect_to event_tasks_path(@event)
@@ -47,10 +48,16 @@ class TasksController < ApplicationController
 
   private
   def task_params
-    params.require(:task).permit(:name, :description, :deadline, :event_id, :user_id)
+    params.require(:task).permit(:name, :description, :deadline, :event_id, user_ids: [])
   end
 
   def define_event
     @event = Event.find(params[:event_id])
   end
+
+  # def user_id_must_exist
+  #   if @task.user_id = "" || !@task.user_id
+  #     errors.add(:user_id, "person in charge must be checked")
+  #   end
+  # end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,7 +23,6 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.find(params[:id])
-    @task.user = User.find(params[:user_id])
   end
 
   def edit
@@ -54,10 +53,4 @@ class TasksController < ApplicationController
   def define_event
     @event = Event.find(params[:event_id])
   end
-
-  # def user_id_must_exist
-  #   if @task.user_id = "" || !@task.user_id
-  #     errors.add(:user_id, "person in charge must be checked")
-  #   end
-  # end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,6 +23,7 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.find(params[:id])
+    @task.user = User.find(params[:user_id])
   end
 
   def edit
@@ -53,4 +54,10 @@ class TasksController < ApplicationController
   def define_event
     @event = Event.find(params[:event_id])
   end
+
+  # def user_id_must_exist
+  #   if @task.user_id = "" || !@task.user_id
+  #     errors.add(:user_id, "person in charge must be checked")
+  #   end
+  # end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,14 +3,25 @@ class Task < ApplicationRecord
   belongs_to :user
   belongs_to :event
 
+  # validates :user_id, presence: true, numericality: { other_than: 1, message: "in charge must be checked"}
   validates :name, presence: true, length:{maximum: 30}
   validates :description, length:{maximum: 200}
   validates :deadline, presence: true
   validate :deadline_cannot_be_in_the_past
+  # validate :user_id_must_exist
 
   def deadline_cannot_be_in_the_past
     if deadline.present? && deadline < Date.today
       errors.add(:deadline, "can't be in the past")
     end
   end
+
+private
+
+def user_id_must_exist
+  if user_id = ""
+    errors.add(:user_id, "person in charge must be checked")
+  end
+end
+
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,10 +1,10 @@
 class Task < ApplicationRecord
-  attr_accessor :user_id, :event_id
+  attr_accessor :user_ids, :event_id
   has_many :task_users
   has_many :users, through: :task_users
-
   belongs_to :event
-  # validates :user_id, presence: true, numericality: { other_than: 1, message: "in charge must be checked"}
+
+  # validates :user_ids, presence: true, numericality: { other_than: 1, message: "in charge must be checked"}
   # validate :user_id_must_exist
   validates :name, presence: true, length:{maximum: 30}
   validates :description, length:{maximum: 200}
@@ -19,9 +19,12 @@ class Task < ApplicationRecord
 
   private
 
-  def user_id_must_exist
-    if user.id = ""
-      return errors.add(:user_id, "person in charge must be checked")
-    end
-  end
+  # def user_id_must_exist
+  #   if !user_id || user_ids = []
+  #   # user_ids.each do |user|
+  #   # if !user_id || user_id = ""
+  #     return errors.add(:user_ids, "person in charge must be checked")
+  #   end
+  # # end
+  # end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,8 +1,11 @@
 class Task < ApplicationRecord
   attr_accessor :user_id, :event_id
-  belongs_to :user
-  belongs_to :event
+  has_many :task_users
+  has_many :users, through: :task_users
 
+  belongs_to :event
+  # validates :user_id, presence: true, numericality: { other_than: 1, message: "in charge must be checked"}
+  # validate :user_id_must_exist
   validates :name, presence: true, length:{maximum: 30}
   validates :description, length:{maximum: 200}
   validates :deadline, presence: true
@@ -11,6 +14,14 @@ class Task < ApplicationRecord
   def deadline_cannot_be_in_the_past
     if deadline.present? && deadline < Date.today
       errors.add(:deadline, "can't be in the past")
+    end
+  end
+
+  private
+
+  def user_id_must_exist
+    if user.id = ""
+      return errors.add(:user_id, "person in charge must be checked")
     end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,25 +3,14 @@ class Task < ApplicationRecord
   belongs_to :user
   belongs_to :event
 
-  # validates :user_id, presence: true, numericality: { other_than: 1, message: "in charge must be checked"}
   validates :name, presence: true, length:{maximum: 30}
   validates :description, length:{maximum: 200}
   validates :deadline, presence: true
   validate :deadline_cannot_be_in_the_past
-  # validate :user_id_must_exist
 
   def deadline_cannot_be_in_the_past
     if deadline.present? && deadline < Date.today
       errors.add(:deadline, "can't be in the past")
     end
   end
-
-private
-
-def user_id_must_exist
-  if user_id = ""
-    errors.add(:user_id, "person in charge must be checked")
-  end
-end
-
 end

--- a/app/models/task_user.rb
+++ b/app/models/task_user.rb
@@ -1,0 +1,4 @@
+class TaskUser < ApplicationRecord
+  belongs_to :task
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :tasks, dependent: :destroy
+  has_many :task_users
+  has_many :tasks, through: :task_users, dependent: :destroy
   has_many :events, dependent: :destroy
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,5 @@
 <h2>Sign up</h2>
+<%= render 'shared/error_messages', model: @user %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -7,7 +8,7 @@
   <div class="field">
     <%= f.label :nickname %><br />
     <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
-  </div>  
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -30,37 +31,37 @@
   <div class="field">
     <%= f.label :gender_id %><br />
     <%= f.select :gender_id, [["男", 1], ["女", 2]], include_blank: "選択して下さい" %>
-  </div>  
+  </div>
 
   <div class="field">
     <%= f.label :hobby %><br />
     <%= f.text_area :hobby, autofocus: true, autocomplete: "hobby" %>
-  </div>  
+  </div>
 
     <div class="field">
     <%= f.label :comment %><br />
     <%= f.text_area :comment, autofocus: true, autocomplete: "comment" %>
-  </div>  
+  </div>
 
     <div class="field">
     <%= f.label :age %><br />
     <%= f.text_field :age, autofocus: true, autocomplete: "age" %>
-  </div>  
+  </div>
 
     <div class="field">
     <%= f.label :prefecture_id %><br />
     <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {prompt: "選択してください"}) %>
-  </div>  
+  </div>
 
       <div class="field">
     <%= f.label :city %><br />
     <%= f.text_field :city, autofocus: true, autocomplete: "city" %>
-  </div>  
+  </div>
 
       <div class="field">
     <%= f.label :address %><br />
     <%= f.text_field :address, autofocus: true, autocomplete: "address" %>
-  </div>  
+  </div>
 
 
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,5 @@
 <h2>Log in</h2>
+<%= render 'shared/error_messages', model: @user %>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,23 +30,20 @@
           <% @userevents.each do |userevent| %>
              <% if userevent.event_id == event.id %>
                <%= userevent.user.nickname %>
-
+             
              <% end %>
           <% end %>
 
           <%= link_to "編集", event_path(event.id), class:"arrange" %>
 
-    <%# タスク作成とタスク一覧 %>
-    <% if user_signed_in? %>
-      <% @userevents.each do |userevent| %>
-        <% if userevent.event_id == event.id && userevent.user_id == current_user.id %>
-          <%= link_to 'タスク作成', new_event_task_path(event) %>
+
+
+
+        <%= link_to 'タスク作成', new_event_task_path(event) %>
         <% if event.tasks.length > 0 %>
           <%= link_to 'タスク一覧', event_tasks_path(event) %>
         <% end %>
-      <% end %>
-      <% end %>
-    <% end %>
+
     </div>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,19 +30,23 @@
           <% @userevents.each do |userevent| %>
              <% if userevent.event_id == event.id %>
                <%= userevent.user.nickname %>
-             
+
              <% end %>
           <% end %>
 
           <%= link_to "編集", event_path(event.id), class:"arrange" %>
 
-
-
-
-        <%= link_to 'タスク作成', new_event_task_path(event) %>
-        <% if event.tasks.length > 0 %>
-          <%= link_to 'タスク一覧', event_tasks_path(event) %>
+  <%# タスク作成とタスク一覧 %>
+    <% if user_signed_in? %>
+      <% @userevents.each do |userevent| %>
+        <% if userevent.event_id == event.id && userevent.user_id == current_user.id %>
+          <%= link_to 'タスク作成', new_event_task_path(event) %>
+          <% if event.tasks.length > 0 %>
+            <%= link_to 'タスク一覧', event_tasks_path(event) %>
+          <% end %>
         <% end %>
+      <% end %>
+    <% end %>
 
     </div>
   <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,20 +30,23 @@
           <% @userevents.each do |userevent| %>
              <% if userevent.event_id == event.id %>
                <%= userevent.user.nickname %>
-             
+
              <% end %>
           <% end %>
 
           <%= link_to "編集", event_path(event.id), class:"arrange" %>
 
-
-
-
-        <%= link_to 'タスク作成', new_event_task_path(event) %>
+    <%# タスク作成とタスク一覧 %>
+    <% if user_signed_in? %>
+      <% @userevents.each do |userevent| %>
+        <% if userevent.event_id == event.id && userevent.user_id == current_user.id %>
+          <%= link_to 'タスク作成', new_event_task_path(event) %>
         <% if event.tasks.length > 0 %>
           <%= link_to 'タスク一覧', event_tasks_path(event) %>
         <% end %>
-
+      <% end %>
+      <% end %>
+    <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,17 @@
   </head>
 
   <body>
+    <header>
+      <div class="logo"><%= link_to 'WEvent', root_path %></div>
+      <% if user_signed_in? %>
+        <div class="username"><%= current_user.nickname %></div>
+        <div class="login-logout-bnt"><%= link_to 'ログアウト', destroy_user_session_path(current_user.id), method: :delete %></div>
+      <% else %>
+        <div class="login-logout-bnt"><%= link_to 'ログイン', new_user_session_path %></div>
+        <div class="login-logout-bnt"><%= link_to '登録', new_user_registration_path %></div>
+      <% end %>
+
+    </header>
     <%= yield %>
   </body>
 </html>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -2,7 +2,7 @@
 <%= form.text_field :name, placeholder: '課題名、30文字以内' %>
 <%= form.text_area :description, placeholder: 'タスク詳細、200文字以内'%>
 <label for="user_id">タスク担当を選択してください</label>
-<select name="user_id">
+<select name="user_ids[]" multiple>
     <option hidden value="1">タスク担当を選択してください</option>
     <% @event.users.all.each do |user| %>
     <option value= <%= user.id %>><%= user.nickname %></option>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,11 +1,12 @@
 <%= render 'shared/error_messages', model: @task %>
 <%= form.text_field :name, placeholder: '課題名、30文字以内' %>
 <%= form.text_area :description, placeholder: 'タスク詳細、200文字以内'%>
+<label for="user_id">タスク担当を選択してください</label>
 <select name="user_id">
-  <option value="">タスク担当を選択してください</option>
-    <% User.all.each do |user| %>
-      <option value= <%= user.id %>><%= user.nickname %></option>
-    <% end %>
+    <option hidden value="1">タスク担当を選択してください</option>
+    <% @event.users.all.each do |user| %>
+    <option value= <%= user.id %>><%= user.nickname %></option>
+  <% end %>
 </select>
 <p>締め切り：</p>
 <%= raw sprintf(

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,9 @@
 <%# <% if user_signed_in? %>
   <% @tasks.each do |task| %>
+    <div class="event">
+      <%= link_to task.event.name, event_path(task.event.id) %>
+    </div>
+
     <%= task.name %>
     <%= task.user.nickname%>
     <%= task.deadline%>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,3 @@
-<%# <% if user_signed_in? %>
   <% @tasks.each do |task| %>
     <div class="event">
       <%= link_to task.event.name, event_path(task.event.id) %>
@@ -13,6 +12,3 @@
     <%= link_to '編集', edit_event_task_path(@event.id, task.id) %>
     <%= link_to 'タスクを消去', event_task_path(@event.id, task.id), method: :delete %>
   <% end %>
-<%# <% else %>
-  <%# <% %>
-<%# <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,7 +5,9 @@
     </div>
 
     <%= task.name %>
-    <%= task.user.nickname%>
+    <% task.users.each do |user| %>
+     <%= user.nickname %>
+    <% end %>
     <%= task.deadline%>
     <%= link_to '詳細', event_task_path(@event.id, task.id), method: :get%>
     <%= link_to '編集', edit_event_task_path(@event.id, task.id) %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,7 +4,9 @@
 
 <div class="task-body">
   <%= @task.name %>
-    <%= @task.user.nickname%>
+    <% @task.users.each do |user| %>
+     <%= user.nickname %>
+    <% end %>
     <%= @task.deadline%>
     <%= @task.description %>
     <%= link_to '編集', edit_event_task_path(@event.id, @task.id) %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,3 +1,7 @@
+<div class="event">
+  <%= link_to @task.event.name, event_path(@task.event.id) %>
+</div>
+
 <div class="task-body">
   <%= @task.name %>
     <%= @task.user.nickname%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   resources :events, only: [:index, :new, :create, :destroy, :show] do
     resources :tasks
   end
-  
+
   resources :rooms, only: [:new, :create] do
     resources :messages, only: [:index, :new, :create]
   end
+
+end

--- a/db/migrate/20210220093627_create_tasks.rb
+++ b/db/migrate/20210220093627_create_tasks.rb
@@ -3,7 +3,6 @@ class CreateTasks < ActiveRecord::Migration[6.0]
     create_table :tasks do |t|
       t.string      :name, null: false, default: ""
       t.text        :description
-      t.references  :user, null: false, foreign_key: true
       t.references  :event, null: false, foreign_key: true
       t.date        :deadline
       t.timestamps

--- a/db/migrate/20210328134507_create_task_users.rb
+++ b/db/migrate/20210328134507_create_task_users.rb
@@ -1,0 +1,9 @@
+class CreateTaskUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :task_users do |t|
+      t.references :task, foreing_key: true
+      t.references :user, foreing_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_031944) do
+ActiveRecord::Schema.define(version: 2021_03_28_134507) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -47,16 +47,23 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "task_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "task_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["task_id"], name: "index_task_users_on_task_id"
+    t.index ["user_id"], name: "index_task_users_on_user_id"
+  end
+
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.text "description"
-    t.bigint "user_id", null: false
     t.bigint "event_id", null: false
     t.date "deadline"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id"], name: "index_tasks_on_event_id"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "user_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -93,7 +100,6 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
   add_foreign_key "tasks", "events"
-  add_foreign_key "tasks", "users"
   add_foreign_key "user_events", "events"
   add_foreign_key "user_events", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2021_03_11_031944) do
-
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -23,16 +21,6 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
-
-  create_table "user_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "event_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["event_id"], name: "index_user_events_on_event_id"
-    t.index ["user_id"], name: "index_user_events_on_user_id"
-
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -57,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
@@ -68,7 +57,15 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id"], name: "index_tasks_on_event_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
+  end
 
+  create_table "user_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "event_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_user_events_on_event_id"
+    t.index ["user_id"], name: "index_user_events_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -91,15 +88,12 @@ ActiveRecord::Schema.define(version: 2021_03_11_031944) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "user_events", "events"
-  add_foreign_key "user_events", "users"
-
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"
   add_foreign_key "room_users", "users"
-
   add_foreign_key "tasks", "events"
   add_foreign_key "tasks", "users"
-
+  add_foreign_key "user_events", "events"
+  add_foreign_key "user_events", "users"
 end

--- a/test/fixtures/task_users.yml
+++ b/test/fixtures/task_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/task_user_test.rb
+++ b/test/models/task_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TaskUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
イベント参加者のみタスクふれるように実装
１つのタスクを数人の担当を指定できる機能を実装
ユザーのログイン、ログアウト、登録機能を実装
イベントに参加しているユーザーのみがタスクの作成と一覧ボタンが見えるように編集
タスクページでイベントページへ遷移するボタンを追加

次回の課題：
user_id未選択時のエラー解決
ユザーがログインしてから他のページに遷移されていないエラーを解決